### PR TITLE
Add support for `?inline` queries

### DIFF
--- a/src/__fixtures__/inline.js
+++ b/src/__fixtures__/inline.js
@@ -1,0 +1,1 @@
+import sample from "./sample.scss?inline";

--- a/src/__fixtures__/invalid.js
+++ b/src/__fixtures__/invalid.js
@@ -1,3 +1,3 @@
-import { foo } from './sample.scss';
+import { foo } from "./sample.scss";
 
 console.log(foo);

--- a/src/__fixtures__/nested.js
+++ b/src/__fixtures__/nested.js
@@ -1,1 +1,1 @@
-import nested from './nested/nested.scss';
+import nested from "./nested/nested.scss";

--- a/src/__fixtures__/precision.js
+++ b/src/__fixtures__/precision.js
@@ -1,1 +1,1 @@
-import precision from './precision.scss';
+import precision from "./precision.scss";

--- a/src/__fixtures__/sample.js
+++ b/src/__fixtures__/sample.js
@@ -1,7 +1,7 @@
-import sideEffectStyles from './sample.scss';
+import sideEffectStyles from "./sample.scss";
 
-if (typeof sideEffectStyles === 'string') {
-  const style = document.createElement('style');
+if (typeof sideEffectStyles === "string") {
+  const style = document.createElement("style");
   style.styleSheet.cssText = sideEffectStyles;
   document.head.appendChild(style);
 }

--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -2,16 +2,18 @@
 
 exports[`babel-plugin-transform-scss-import-to-string > resolves and transpiles scss file 1`] = `
 "const sideEffectStyles = ".foo {\\n  color: cyan;\\n}\\n\\n.bar {\\n  font-size: 32px;\\n}";
-if (typeof sideEffectStyles === 'string') {
-  const style = document.createElement('style');
+if (typeof sideEffectStyles === "string") {
+  const style = document.createElement("style");
   style.styleSheet.cssText = sideEffectStyles;
   document.head.appendChild(style);
 }"
 `;
 
 exports[`babel-plugin-transform-scss-import-to-string > skips non-default import specifier 1`] = `
-"import { foo } from './sample.scss';
+"import { foo } from "./sample.scss";
 console.log(foo);"
 `;
 
 exports[`babel-plugin-transform-scss-import-to-string > supports custom node-sass options 1`] = `"const precision = ".baz {\\n  transform: translateX(1.87654321px);\\n}";"`;
+
+exports[`babel-plugin-transform-scss-import-to-string > supports scss files with inline query 1`] = `"const sample = ".foo {\\n  color: cyan;\\n}\\n\\n.bar {\\n  font-size: 32px;\\n}";"`;

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -30,4 +30,8 @@ describe("babel-plugin-transform-scss-import-to-string", () => {
   test("supports nested scss files", () => {
     expect(() => transformFixture("nested.js")).not.toThrow();
   });
+
+  test("supports scss files with inline query", () => {
+    expect(transformFixture("inline.js")).toMatchSnapshot();
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,15 +30,13 @@ function transformScssToString(babel: Babel): {
     name: "babel-plugin-transform-scss-import-to-string",
     visitor: {
       ImportDeclaration(path, state) {
-        // Drop these options
         const userOptions = state.opts;
         // Filter *.scss imports
-        if (!/\.scss$/.test(path.node.source.value)) return;
-        // Get full path to file and transpile it
+        if (!/\.scss(\?inline)?$/.test(path.node.source.value)) return;
         const scssFileDirectory = resolve(dirname(state.file.opts.filename));
         const fullScssFilePath = join(
           scssFileDirectory,
-          path.node.source.value,
+          path.node.source.value.replace(/\?inline$/, ""),
         );
         const projectRoot = process.cwd();
         const nodeModulesPath = join(projectRoot, "node_modules");


### PR DESCRIPTION
Nowadays, when importing default/named SCSS imports (e.g. `import Styles from "./styles.scss?inline`), Vite complains about this:

```
Default and named imports from CSS files are deprecated. Use the ?inline query instead. For example: import Styles from "./styles.scss?inline"
Plugin: vite:import-analysis
File: /Users/xsu1010/Repos/testing/src/styles.ts
```

This PR adds a check for `?inline` queries and strips it from the file name.

Fixes #1.